### PR TITLE
…Fix RuntimeError when reading packets with zero samples.

### DIFF
--- a/pyxtf/xtf_ctypes.py
+++ b/pyxtf/xtf_ctypes.py
@@ -593,7 +593,7 @@ class XTFPingHeader(XTFPacketStart):
 
                 # Read the data and output as a numpy array of the specified bytes-per-sample
                 samples = buffer.read(n_bytes)
-                if not samples:
+                if n_bytes and not samples:
                     raise RuntimeError('File ended while reading data packets (file corrupt?)')
 
                 bytes_remaining -= len(samples)

--- a/pyxtf/xtf_ctypes.py
+++ b/pyxtf/xtf_ctypes.py
@@ -593,7 +593,7 @@ class XTFPingHeader(XTFPacketStart):
 
                 # Read the data and output as a numpy array of the specified bytes-per-sample
                 samples = buffer.read(n_bytes)
-                if n_bytes and not samples:
+                if n_bytes > 0 and not samples:
                     raise RuntimeError('File ended while reading data packets (file corrupt?)')
 
                 bytes_remaining -= len(samples)


### PR DESCRIPTION
Fix RuntimeError when reading packets with zero samples. 
Changed to returning empty sample array.