### PR TITLE
Fix the misread of XTFRawCustomHeader and read the data that follows the header.

### DIFF
--- a/pyxtf/xtf_ctypes.py
+++ b/pyxtf/xtf_ctypes.py
@@ -752,22 +752,22 @@ class XTFRawCustomHeader(XTFPacket):
         ('HeaderType', ctypes.c_uint8),
         ('ManufacturerID', ctypes.c_uint8),
         ('SonarID', ctypes.c_uint16),
-        ('PacketID', ctypes.c_uint16 * 2),
-        ('Reserved1', ctypes.c_uint32),
+        ('PacketID', ctypes.c_uint16),
+        ('Reserved1', ctypes.c_uint16 * 1),
         ('NumBytesThisRecord', ctypes.c_uint32),
-        ('Id', ctypes.c_int32),
-        ('SoundVelocity', ctypes.c_float),
-        ('Intensity', ctypes.c_float),
-        ('Quality', ctypes.c_int32),
-        ('TwoWayTravelTime', ctypes.c_float),
         ('Year', ctypes.c_uint16),
         ('Month', ctypes.c_uint8),
         ('Day', ctypes.c_uint8),
         ('Hour', ctypes.c_uint8),
         ('Minute', ctypes.c_uint8),
         ('Second', ctypes.c_uint8),
-        ('Millisecond', ctypes.c_uint16),
-        ('Reserved2', ctypes.c_uint8 * 7)
+        ('HSecond', ctypes.c_uint8),
+        ('JulianDay', ctypes.c_uint16),
+        ('Reserved2', ctypes.c_uint16 * 2),
+        ('PingNumber', ctypes.c_uint32),
+        ('TimeTag', ctypes.c_uint32),
+        ('NumCustomerBytes', ctypes.c_uint32),
+        ('Reserved3', ctypes.c_uint8 * 24),
     ]
 
     @classmethod
@@ -776,10 +776,14 @@ class XTFRawCustomHeader(XTFPacket):
         if obj.MagicNumber != 0xFACE:
             raise RuntimeError('XTF packet does not start with the correct identifier (0xFACE).')
 
+        n_bytes = obj.NumBytesThisRecord - ctypes.sizeof(cls)
+        obj.data = buffer.read(n_bytes)
+
         return obj
 
     def __init__(self):
         super().__init__()
+        self.data = b''
         self.MagicNumber = 0xFACE
         self.HeaderType = XTFHeaderType.custom_vendor_data.value
 

--- a/pyxtf/xtf_ctypes.pyi
+++ b/pyxtf/xtf_ctypes.pyi
@@ -649,41 +649,41 @@ class XTFRawCustomHeader(XTFPacket):
     PacketID = None  # type: CField
     Reserved1 = None  # type: CField
     NumBytesThisRecord = None  # type: CField
-    Id = None  # type: CField
-    SoundVelocity = None  # type: CField
-    Intensity = None  # type: CField
-    Quality = None  # type: CField
-    TwoWayTravelTime = None  # type: CField
     Year = None  # type: CField
     Month = None  # type: CField
     Day = None  # type: CField
     Hour = None  # type: CField
     Minute = None  # type: CField
     Second = None  # type: CField
-    Millisecond = None  # type: CField
+    HSecond = None  # type: CField
+    JulianDay = None  # type: CField
     Reserved2 = None  # type: CField
+    PingNumber = None  # type: CField
+    TimeTag = None  # type: CField
+    NumCustomerBytes = None  # type: CField
+    Reserved3 = None  # type: CField
 
     def __init__(self):
         self.MagicNumber = None  # type: ctypes.c_ushort
         self.HeaderType = None  # type: ctypes.c_ubyte
         self.ManufacturerID = None  # type: ctypes.c_ubyte
         self.SonarID = None  # type: ctypes.c_ushort
-        self.PacketID = None  # type: ctypes.Array[ctypes.c_ushort]
-        self.Reserved1 = None  # type: ctypes.c_uint
+        self.PacketID = None  # type: ctypes.c_ushort
+        self.Reserved1 = None  # type: ctypes.Array[ctypes.c_ushort]
         self.NumBytesThisRecord = None  # type: ctypes.c_uint
-        self.Id = None  # type: ctypes.c_int
-        self.SoundVelocity = None  # type: ctypes.c_float
-        self.Intensity = None  # type: ctypes.c_float
-        self.Quality = None  # type: ctypes.c_int
-        self.TwoWayTravelTime = None  # type: ctypes.c_float
         self.Year = None  # type: ctypes.c_ushort
         self.Month = None  # type: ctypes.c_ubyte
         self.Day = None  # type: ctypes.c_ubyte
         self.Hour = None  # type: ctypes.c_ubyte
         self.Minute = None  # type: ctypes.c_ubyte
         self.Second = None  # type: ctypes.c_ubyte
-        self.Millisecond = None  # type: ctypes.c_ushort
-        self.Reserved2 = None  # type: ctypes.Array[ctypes.c_ubyte]
+        self.HSecond = None  # type: ctypes.c_ubyte
+        self.JulianDay = None  # type: ctypes.c_ushort
+        self.Reserved2 = None  # type: ctypes.Array[ctypes.c_ushort]
+        self.PingNumber = None  # type: ctypes.c_uint
+        self.TimeTag = None  # type: ctypes.c_uint
+        self.NumCustomerBytes = None  # type: ctypes.c_uint
+        self.Reserved3 = None  # type: ctypes.Array[ctypes.c_ubyte]
     def get_time(self):
         pass
     def to_bytes(self):


### PR DESCRIPTION
After reading eXtented Triton Format (XTF) FILE FORMAT SPECIFICATION REV.42, I rewrite the fields of [`class XTFRawCustomHeader`](https://github.com/oysstu/pyxtf/blob/master/pyxtf/xtf_ctypes.py#L748) and make the function [`create_from_buffer`](https://github.com/oysstu/pyxtf/blob/master/pyxtf/xtf_ctypes.py#L774) read the data that follows the XTFRawCustomHeader.