### PR TITLE
Fix XTFQPSMBEEntry according to spec

### DIFF
--- a/pyxtf/xtf_ctypes.py
+++ b/pyxtf/xtf_ctypes.py
@@ -738,9 +738,8 @@ class XTFQPSMBEEntry(XTFBase):
         ('Quality', ctypes.c_int),
         ('TwoWayTravelTime', ctypes.c_double),
         ('DeltaTime', ctypes.c_double),
-        ('OffsetX', ctypes.c_double),  # Number of bytes without padding (header+data)
-        ('OffsetY', ctypes.c_double),
-        ('OffsetZ', ctypes.c_double),
+        ('BeamAngle', ctypes.c_double),
+        ('TiltAngle', ctypes.c_double),
         ('Reserved', ctypes.c_float * 4)
     ]
 


### PR DESCRIPTION
Hello there,


during my recent work with multibeam data, I have encountered a discrepancy between the implementation of the `XTFQPSMBEEntry` class in the codebase and its specification as outlined in "XTF File Format Specification r42". The specification can be accessed [here](https://www.ecagroup.com/en/xtf-file-format).

To illustrate, Table 15 of the specification accurately defines `XTQPSMultiTXEntry` as it is in the code base line 718 `xtf_ctypes.py`. Table 16, which shows `XTFQPSMBEEntry` (Chapter 4.2.10, page 33), appears to have an incorrect title in the current revision of the document. I was unable to find a more recent version (revision 44, as described in the readme of this repo).

Attached below are the relevant sections from the specification for your reference:

Table 15: Definition of XTQPSMultiTXEntry
![image](https://github.com/oysstu/pyxtf/assets/58865118/e2f8d82a-faa0-4f49-97e8-c493931d0df0)

Table 16: Definition of XTFQPSMBEEntry (wrongly named)
![image](https://github.com/oysstu/pyxtf/assets/58865118/a8048bd6-1c57-4ba1-9c21-5ddce6d1abc3)

Please review this PR and consider merging it to align the class definition to the XTF specification.


Thank you!